### PR TITLE
Added descriptions of the demo for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 This demo will explore how to use Karpenter to scale node groups using different metrics.
 
+The set of directions listed in this README contain the setup common amongst all demos.
 ## Setup
 
 ### Environment
+Set up environment variables for all demos.
 
 ```bash
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
@@ -28,6 +30,7 @@ eksctl create cluster \
 ```
 
 ### Karpenter Controller
+Karpenter has a dependency on cert-manager and prometheus. Install these with settings specific to Karpenter and apply our manifest to the cluster.
 
 ```bash
 helm repo add jetstack https://charts.jetstack.io
@@ -61,6 +64,7 @@ kubectl apply -f https://raw.githubusercontent.com/awslabs/karpenter/v0.1.1/rele
 ```
 
 ### AWS Credentials
+This is the identity of the Karpenter controller. Karpenter needs these permissions in order for it to control the autoscaling mechanisms present in all the following demos.
 
 ```bash
 aws iam create-policy --policy-name Karpenter --policy-document "$(cat <<-EOM
@@ -99,6 +103,7 @@ aws iam create-policy --policy-name Karpenter --policy-document "$(cat <<-EOM
 EOM
 )"
 ```
+This wires up permissions using IRSA by adding a secret with permissions to AWS resources into the default service account.
 
 ```bash
 eksctl utils associate-iam-oidc-provider --region=${REGION} --cluster=${CLUSTER_NAME} --approve
@@ -109,11 +114,14 @@ eksctl create iamserviceaccount --cluster ${CLUSTER_NAME} \
 --override-existing-serviceaccounts \
 --approve
 
+# Due to a weird side effect of IRSA, we need to restart the Karpenter pod so that the newly created serviceaccount's secret is wired up.
 kubectl delete pods -n karpenter -l control-plane=karpenter
 kubectl get pods -n karpenter
 ```
 
 ## Demos
+Continue to any demo below. 
+Make sure you keep the environment variables defined above in the same terminal for the following demos.
 
 * [Queue Length](./queue-length/)
 * [Reserved Capacity](./reserved-capacity)

--- a/reserved-capacity/README.md
+++ b/reserved-capacity/README.md
@@ -1,22 +1,31 @@
 # Reserved Capacity Demo
 
-## Apply YAML and Watch
+## Apply YAML
+Download the manifest and inject your nodegroup details into it.
 
 ```bash
 wget https://raw.githubusercontent.com/ellistarn/karpenter-aws-demo/main/reserved-capacity/manifest.yaml
 
-NODE_GROUP_ARN=$(aws eks describe-nodegroup --nodegroup-name karpenter-aws-demo --cluster-name $USER-karpenter-aws-demo --output json | jq -r ".nodegroup.nodegroupArn") \
+NODE_GROUP_ARN=$(aws eks describe-nodegroup --nodegroup-name demo --cluster-name $USER-karpenter-aws-demo --output json | jq -r ".nodegroup.nodegroupArn") \
 envsubst < manifest.yaml | kubectl apply -f -
+```
+## Watch
+Use the following commands to observe the demo in real time.
 
-# Manually open in 5 separate terminals
+```bash
+# Open in 5 separate terminals
 watch 'kubectl get pods -n karpenter-reserved-capacity-demo'
 watch 'kubectl get nodes'
-watch -d 'kubectl get metricsproducers.autoscaling.karpenter.sh demo -n karpenter-reserved-capacity-demo -ojson | jq .status.reservedCapacity'
-watch -d 'kubectl get horizontalautoscalers.autoscaling.karpenter.sh capacity -n karpenter-reserved-capacity-demo -ojson | jq ".status" | jq del\(.conditions\)'
+# The MetricsProducer is responsible for calculating the %used of memory, cpu, and pods for the cluster. It will periodically calculate the value and report it in its status. This value is scraped by prometheus and eventually used in the HorizontalAutoscaler
+watch -d 'kubectl get metricsproducers.autoscaling.karpenter.sh demo -n karpenter-reserved-capacity-demo -ojson | jq ".status.reservedCapacity"'
+# The HorizontalAutoscaler is responsible for computing the desired number of replicas. In this case it will recommend scale up of the nodes to remain at 60% usage for memory and cpu.
+watch -d 'kubectl get horizontalautoscalers.autoscaling.karpenter.sh capacity -n karpenter-reserved-capacity-demo -ojson | jq ".status" | jq "del(.conditions)"'
+# The ScalableNodeGroup is targeted by the HorizontalAutoscaler and works with EKS Managed Node Groups to reconcile the amount of node replicas.
 watch -d 'kubectl get scalablenodegroups.autoscaling.karpenter.sh capacity -n karpenter-reserved-capacity-demo -ojson | jq "del(.status.conditions)"| jq ".spec, .status"'
 ```
 
 ## Scale the Pods and Nodes
+Manually change the replicas of the deployments.
 
 ```bash
 wget https://raw.githubusercontent.com/ellistarn/karpenter-aws-demo/main/reserved-capacity/inflate.yaml
@@ -27,10 +36,12 @@ REPLICAS=30 envsubst < inflate.yaml | kubectl apply -f -
 ```
 
 ## Cleanup
+This only cleans up the resources associated with the queue-length demo. To clean up all resources, head to the [parent doc](..).
 
 ```bash
 rm manifest.yaml
 rm inflate.yaml
+
 kubectl delete namespace karpenter-reserved-capacity-demo
 # Clean up stacks
 eksctl delete iamserviceaccount --cluster $CLUSTER_NAME --name default --namespace karpenter-reserved-capacity-demo


### PR DESCRIPTION
This PR adds more descriptions for each step of the Demo for both the queue-length demo and the reserved-capacity demo.
- Added more background to the reason for the demos and an overview for each
- Added detailed notes for each step to explain the purpose of each Kubernetes command
- Changed QueueName to be `$USER-karpenter-demo-queue` from `$USER-demo-queue`